### PR TITLE
introduce generator option "useOptionals"

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@
  * useBeanValidation: generate validation annotations (default `true`)
  * useGenericResponse: return generic container or specifc model, e.g. `Model` vs. `HttpResponse<Model>` (default `true`)
  * jacksonDatabindNullable: add container `JsonNullable` to model objects that are nullable (default `false`)
+ * useOptionals: optional parameters are generated as `java.util.Optional` (default `true`)
+ 
 
 ### Null handling and default values
 

--- a/src/it/optional/pom.xml
+++ b/src/it/optional/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>@project.groupId@</groupId>
+		<artifactId>@project.artifactId@-it</artifactId>
+		<version>LOCAL-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>@project.artifactId@-it-validation</artifactId>
+
+	<dependencies>
+
+		<!-- micronaut -->
+		<dependency>
+			<groupId>io.micronaut</groupId>
+			<artifactId>micronaut-validation</artifactId>
+		</dependency>
+
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.openapitools</groupId>
+				<artifactId>openapi-generator-maven-plugin</artifactId>
+				<configuration>
+					<configOptions>
+						<useOptionals>true</useOptionals>
+					</configOptions>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/src/it/optional/src/main/resources/openapi/spec.yaml
+++ b/src/it/optional/src/main/resources/openapi/spec.yaml
@@ -1,0 +1,40 @@
+openapi: 3.0.2
+info:
+  title: Test Spec
+  version: '0'
+paths:
+  /elements:
+    post:
+      tags:
+        - optionals
+      operationId: post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+      responses:
+        201:
+          description: C
+    get:
+      operationId: get
+      tags:
+        - optionals
+      parameters:
+        - in: query
+          name: id
+          schema:
+            type: string
+        - in: query
+          name: size
+          required: true
+          schema:
+            type: integer
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: string
+

--- a/src/it/optional/src/test/java/codegen/OptionalsApiController.java
+++ b/src/it/optional/src/test/java/codegen/OptionalsApiController.java
@@ -1,0 +1,22 @@
+package codegen;
+
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.annotation.Controller;
+
+import javax.annotation.Nonnull;
+import java.util.Optional;
+
+@Controller
+public class OptionalsApiController implements codegen.OptionalsApi {
+
+
+    @Override
+    public HttpResponse<String> get(Integer size, @Nonnull Optional<String> id) {
+        return null;
+    }
+
+    @Override
+    public HttpResponse<?> post(String body) {
+        return null;
+    }
+}

--- a/src/it/pom.xml
+++ b/src/it/pom.xml
@@ -194,6 +194,7 @@
 					<output>${project.build.directory}</output>
 					<configOptions>
 						<useBeanValidation>false</useBeanValidation>
+						<useOptionals>false</useOptionals>
 					</configOptions>
 				</configuration>
 				<dependencies>

--- a/src/main/java/org/openapitools/codegen/languages/MicronautCodegen.java
+++ b/src/main/java/org/openapitools/codegen/languages/MicronautCodegen.java
@@ -48,6 +48,7 @@ public class MicronautCodegen extends AbstractJavaCodegen
 	public static final String INTROSPECTED = "introspected";
 	public static final String DATETIME_RELAXED = "dateTimeRelaxed";
 	public static final String JACKSON_DATABIND_NULLABLE = "jacksonDatabindNullable";
+	public static final String OPTIONALS = "useOptionals";
 	public static final Map<String, Class<?>> CUSTOM_FORMATS = Map.of(
 			"temporal-amount", TemporalAmount.class,
 			"period", Period.class,
@@ -69,6 +70,7 @@ public class MicronautCodegen extends AbstractJavaCodegen
 	private boolean useBeanValidation = true;
 	private boolean useGenericResponse = true;
 	private boolean jacksonDatabindNullable = false;
+	private boolean useOptionals = true;
 
 	public MicronautCodegen() {
 
@@ -80,6 +82,7 @@ public class MicronautCodegen extends AbstractJavaCodegen
 		cliOptions.add(CliOption.newBoolean(
 				JACKSON_DATABIND_NULLABLE, "Add wrapper from jackson-databind-nullable.", jacksonDatabindNullable));
 		cliOptions.add(CliOption.newString(CLIENT_ID, "ClientId to use."));
+		cliOptions.add(CliOption.newBoolean(OPTIONALS, "use optionals instead of @Nullable."));
 
 		// there is no documentation template yet
 
@@ -95,6 +98,7 @@ public class MicronautCodegen extends AbstractJavaCodegen
 		additionalProperties.put(USE_BEANVALIDATION, useBeanValidation);
 		additionalProperties.put(USE_GENERIC_RESPONSE, useGenericResponse);
 		additionalProperties.put(JACKSON_DATABIND_NULLABLE, jacksonDatabindNullable);
+		additionalProperties.put(OPTIONALS, useOptionals);
 		additionalProperties.put(CodegenConstants.TEMPLATE_DIR, "Micronaut");
 
 		// add custom type mappings
@@ -150,6 +154,9 @@ public class MicronautCodegen extends AbstractJavaCodegen
 		}
 		if (additionalProperties.containsKey(JACKSON_DATABIND_NULLABLE)) {
 			jacksonDatabindNullable = convertPropertyToBooleanAndWriteBack(JACKSON_DATABIND_NULLABLE);
+		}
+		if (additionalProperties.containsKey(OPTIONALS)) {
+			useOptionals = convertPropertyToBooleanAndWriteBack(OPTIONALS);
 		}
 		if (additionalProperties.containsKey(CodegenConstants.GENERATE_API_TESTS)) {
 			generateApiTests = convertPropertyToBooleanAndWriteBack(CodegenConstants.GENERATE_API_TESTS);

--- a/src/main/resources/Micronaut/apiParams.mustache
+++ b/src/main/resources/Micronaut/apiParams.mustache
@@ -11,10 +11,10 @@
 {{/isLong}}{{/isInteger}}{{/maximum}}{{#minLength}}{{^maxLength}}			@javax.validation.constraints.Size(min = {{minLength}})
 {{/maxLength}}{{/minLength}}{{^minLength}}{{#maxLength}}			@javax.validation.constraints.Size(max = {{maxLength}})
 {{/maxLength}}{{/minLength}}{{#minLength}}{{#maxLength}}			@javax.validation.constraints.Size(min = {{minLength}}, max = {{maxLength}})
-{{/maxLength}}{{/minLength}}{{/useBeanValidation}}{{^required}}{{^isBodyParam}}			@javax.annotation.Nullable
+{{/maxLength}}{{/minLength}}{{/useBeanValidation}}{{^required}}{{^isBodyParam}}{{^useOptionals}}			@javax.annotation.Nullable{{/useOptionals}}{{#useOptionals}}			@javax.annotation.Nonnull{{/useOptionals}}
 {{/isBodyParam}}{{/required}}{{#isQueryParam}}			@io.micronaut.http.annotation.QueryValue{{^isContainer}}(value = "{{baseName}}"{{#defaultValue}}, defaultValue = "{{defaultValue}}"{{/defaultValue}}){{/isContainer}}
 {{/isQueryParam}}{{#isBodyParam}}			@io.micronaut.http.annotation.Body
 {{/isBodyParam}}{{#isPathParam}}			@io.micronaut.http.annotation.PathVariable(name = "{{baseName}}"{{#defaultValue}}, defaultValue = "{{defaultValue}}"{{/defaultValue}})
 {{/isPathParam}}{{#isHeaderParam}}			@io.micronaut.http.annotation.Header("{{baseName}}")
-{{/isHeaderParam}}			{{{dataType}}} {{paramName}}{{#hasMore}},
+{{/isHeaderParam}}			{{#isBodyParam}}{{{dataType}}}{{/isBodyParam}}{{^isBodyParam}}{{#required}}{{{dataType}}}{{/required}}{{^required}}{{#useOptionals}}java.util.Optional<{{{dataType}}}>{{/useOptionals}}{{^useOptionals}}{{{dataType}}}{{/useOptionals}}{{/required}}{{/isBodyParam}} {{paramName}}{{#hasMore}},
 {{/hasMore}}{{/allParams}}


### PR DESCRIPTION
- supporting java.utils.Optional parameter instead of @javax.annotation.Nullable

```
			<plugin>
				<groupId>org.openapitools</groupId>
				<artifactId>openapi-generator-maven-plugin</artifactId>
                                ...
				<configuration>
                                        ....
					<configOptions>
						<useOptionals>true</useOptionals> <!-- true is default -->
					</configOptions>
				</configuration>
			</plugin>
```

results in 

```
	@io.micronaut.http.annotation.Get("/elements")
	@io.micronaut.http.annotation.Produces("application/json")
	io.micronaut.http.HttpResponse<java.lang.String> get(
			@javax.annotation.Nonnull
			@io.micronaut.http.annotation.QueryValue(value = "id")
			java.util.Optional<java.lang.String> id);
```

