### PR TITLE
Prevent NPE if the content of a response is not defined

### DIFF
--- a/src/it/async-nongeneric/src/main/java/codegen/ResponseController.java
+++ b/src/it/async-nongeneric/src/main/java/codegen/ResponseController.java
@@ -2,6 +2,7 @@ package codegen;
 
 import java.util.List;
 
+import io.micronaut.http.HttpResponse;
 import io.micronaut.http.annotation.Controller;
 import io.reactivex.Completable;
 import io.reactivex.Flowable;
@@ -27,6 +28,11 @@ public class ResponseController implements ResponseApi {
 	@Override
 	public Maybe<Model> maybe(Boolean found) {
 		return found ? Maybe.just(SINGLE) : Maybe.empty();
+	}
+
+	@Override
+	public Completable noContentGet() {
+		return Completable.complete();
 	}
 
 	@Override

--- a/src/it/async-reactor/src/main/java/codegen/ResponseController.java
+++ b/src/it/async-reactor/src/main/java/codegen/ResponseController.java
@@ -29,6 +29,11 @@ public class ResponseController implements ResponseApi {
 	}
 
 	@Override
+	public Mono<HttpResponse<?>> noContentGet() {
+		return Mono.just(HttpResponse.ok());
+	}
+
+	@Override
 	public Mono<HttpResponse<List<Model>>> array() {
 		return Mono.just(HttpResponse.ok(ARRAY));
 	}

--- a/src/it/async/src/main/java/codegen/ResponseController.java
+++ b/src/it/async/src/main/java/codegen/ResponseController.java
@@ -34,6 +34,11 @@ public class ResponseController implements ResponseApi {
 	}
 
 	@Override
+	public Single<HttpResponse<?>> noContentGet() {
+		return Single.just(HttpResponse.ok());
+	}
+
+	@Override
 	public HttpResponse<Flowable<Model>> stream() {
 		return HttpResponse.ok(Flowable.fromIterable(ARRAY));
 	}

--- a/src/it/async/src/main/resources/openapi/spec.yaml
+++ b/src/it/async/src/main/resources/openapi/spec.yaml
@@ -59,6 +59,13 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Model'
+  /noContent:
+    get:
+      tags:
+      - response
+      responses:
+        200:
+          description: Ok but no content defined.
   /stream:
     get:
       operationId: stream

--- a/src/it/async/src/test/java/codegen/ResponseControllerTest.java
+++ b/src/it/async/src/test/java/codegen/ResponseControllerTest.java
@@ -56,6 +56,12 @@ public class ResponseControllerTest implements ResponseApiTestSpec {
 
 	@Test
 	@Override
+	public void noContentGet200() {
+		assert200(() -> client.noContentGet());
+	}
+
+	@Test
+	@Override
 	public void array200() {
 		var response = assert200(() -> client.array());
 		assertEquals(ResponseController.ARRAY, response.body());

--- a/src/main/java/org/openapitools/codegen/languages/MicronautCodegen.java
+++ b/src/main/java/org/openapitools/codegen/languages/MicronautCodegen.java
@@ -40,6 +40,7 @@ import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.media.ComposedSchema;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.media.StringSchema;
+import io.swagger.v3.oas.models.responses.ApiResponse;
 import io.swagger.v3.oas.models.servers.Server;
 
 public class MicronautCodegen extends AbstractJavaCodegen
@@ -265,8 +266,10 @@ public class MicronautCodegen extends AbstractJavaCodegen
 
 		if (supportAsync) {
 			var isVoid = operation.returnType == null;
-			var isStream = source.getResponses().containsKey("200")
-					&& source.getResponses().get("200").getContent().containsKey(MediaType.APPLICATION_JSON_STREAM);
+			var isStream = Optional.ofNullable(source.getResponses().get("200"))
+					.map(ApiResponse::getContent) // may be null
+					.filter(content -> content.containsKey(MediaType.APPLICATION_JSON_STREAM))
+					.isPresent();
 			extensions.put("asyncContainer", typeMapping.get("asyncSingle"));
 			extensions.put("asyncStream", isStream);
 			if (!useGenericResponse) {


### PR DESCRIPTION
The Response Object does not define the `content` as required.
So it might be null.