### PR TITLE
support usage of referenced schema as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
  * useLombokGenerated: add `@lombok.Generated` to all classes (default `false`), usefull for [jacoco](https://github.com/jacoco/jacoco/pull/731)
  * jacksonDatabindNullable: add container `JsonNullable` to model objects that are nullable (default `true`)
  * supportAsync: use reactivex return types, see [Reactive HTTP Request Processing](https://docs.micronaut.io/2.1.3/guide/index.html#reactiveServer)
+ * useReferencedSchemaAsDefault: use the referenced schema's type for instantiation of default values 
 
 ### Null handling and default values
 

--- a/src/it/additional-props-composition/pom.xml
+++ b/src/it/additional-props-composition/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>@project.groupId@</groupId>
+		<artifactId>@project.artifactId@-it</artifactId>
+		<version>LOCAL-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>@project.artifactId@-additional-props-composition</artifactId>
+
+	<dependencies>
+
+		<!-- micronaut -->
+		<dependency>
+			<groupId>io.micronaut</groupId>
+			<artifactId>micronaut-http</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.openapitools</groupId>
+				<artifactId>openapi-generator-maven-plugin</artifactId>
+				<configuration>
+					<generateAliasAsModel>true</generateAliasAsModel>
+					<configOptions>
+						<useOptional>true</useOptional>
+						<supportsAdditionalPropertiesWithComposedSchema>true</supportsAdditionalPropertiesWithComposedSchema>
+						<introspected>false</introspected>
+					</configOptions>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/src/it/additional-props-composition/src/main/resources/openapi/spec.yaml
+++ b/src/it/additional-props-composition/src/main/resources/openapi/spec.yaml
@@ -1,0 +1,48 @@
+openapi: 3.0.2
+info:
+  title: Test Spec
+  version: '0'
+paths: {}
+components:
+  schemas:
+    Property:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+            - Property
+      required:
+        - type
+        - value
+      additionalProperties:
+        oneOf:
+          - $ref: '#/components/schemas/Property'
+          - $ref: '#/components/schemas/Relationship'
+    Relationship:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+            - Relationship
+        object:
+          type: string
+          format: uri
+      required:
+        - type
+        - object
+      additionalProperties:
+        oneOf:
+          - $ref: '#/components/schemas/Property'
+          - $ref: '#/components/schemas/Relationship'
+    Entity:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uri
+      additionalProperties:
+        oneOf:
+          - $ref: '#/components/schemas/Property'
+          - $ref: '#/components/schemas/Relationship'

--- a/src/it/additional-props-composition/src/test/java/codegen/ModelTest.java
+++ b/src/it/additional-props-composition/src/test/java/codegen/ModelTest.java
@@ -1,0 +1,19 @@
+package codegen;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import org.junit.jupiter.api.Test;
+import java.util.Map;
+
+class ModelTest {
+
+	@Test
+	void defaultType() {
+		assertFalse(new Entity() instanceof Map, "Entity should not extend map.");
+		assertDoesNotThrow(() -> new Entity().getAdditionalProperties(), "The additional properties field should have been created.");
+		assertDoesNotThrow(() -> new Entity().setAdditionalProperties(Map.of("my", "property")), "The additional properties field should offer a setter.");
+	}
+
+}

--- a/src/it/referenced-as-default/pom.xml
+++ b/src/it/referenced-as-default/pom.xml
@@ -8,15 +8,11 @@
 		<version>LOCAL-SNAPSHOT</version>
 	</parent>
 
-	<artifactId>@project.artifactId@-it-validation</artifactId>
+	<artifactId>@project.artifactId@-refernece-as-default</artifactId>
 
 	<dependencies>
 
 		<!-- micronaut -->
-		<dependency>
-			<groupId>io.micronaut</groupId>
-			<artifactId>micronaut-validation</artifactId>
-		</dependency>
 		<dependency>
 			<groupId>io.micronaut</groupId>
 			<artifactId>micronaut-http</artifactId>
@@ -35,6 +31,7 @@
 					<configOptions>
 						<useOptional>true</useOptional>
 						<useReferencedSchemaAsDefault>true</useReferencedSchemaAsDefault>
+						<introspected>false</introspected>
 					</configOptions>
 				</configuration>
 			</plugin>

--- a/src/it/referenced-as-default/pom.xml
+++ b/src/it/referenced-as-default/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>@project.groupId@</groupId>
+		<artifactId>@project.artifactId@-it</artifactId>
+		<version>LOCAL-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>@project.artifactId@-it-validation</artifactId>
+
+	<dependencies>
+
+		<!-- micronaut -->
+		<dependency>
+			<groupId>io.micronaut</groupId>
+			<artifactId>micronaut-validation</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.micronaut</groupId>
+			<artifactId>micronaut-http</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.openapitools</groupId>
+				<artifactId>openapi-generator-maven-plugin</artifactId>
+				<configuration>
+					<generateAliasAsModel>true</generateAliasAsModel>
+					<configOptions>
+						<useOptional>true</useOptional>
+						<useReferencedSchemaAsDefault>true</useReferencedSchemaAsDefault>
+					</configOptions>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/src/it/referenced-as-default/src/main/resources/openapi/spec.yaml
+++ b/src/it/referenced-as-default/src/main/resources/openapi/spec.yaml
@@ -1,0 +1,39 @@
+openapi: 3.0.2
+info:
+  title: Test Spec
+  version: '0'
+paths: {}
+components:
+  schemas:
+    positionDefinition:
+      description: A single position
+      type: array
+      minItems: 2
+      maxItems: 2
+      items:
+        type: number
+      additionalProperties: false
+    positionArrayDefinition:
+      description: An array of positions
+      type: array
+      items:
+        $ref: '#/components/schemas/positionDefinition'
+    linearRingDefinition:
+      description: An array of four positions where the first equals the last
+      allOf:
+        - $ref: '#/components/schemas/positionArrayDefinition'
+        - minItems: 4
+    polygonDefinition:
+      description: An array of linear rings
+      type: array
+      items:
+        $ref: '#/components/schemas/linearRingDefinition'
+    Polygon:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+            - Polygon
+        coordinates:
+          $ref: '#/components/schemas/polygonDefinition'

--- a/src/it/referenced-as-default/src/test/java/codegen/ModelTest.java
+++ b/src/it/referenced-as-default/src/test/java/codegen/ModelTest.java
@@ -1,0 +1,14 @@
+package codegen;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class ModelTest {
+
+	@Test
+	void defaultType() {
+		assertTrue(new Polygon().getCoordinates() instanceof PolygonDefinition, "Correct default value.");
+	}
+
+}

--- a/src/main/java/org/openapitools/codegen/languages/MicronautCodegen.java
+++ b/src/main/java/org/openapitools/codegen/languages/MicronautCodegen.java
@@ -1,17 +1,35 @@
 package org.openapitools.codegen.languages;
 
-import io.micronaut.core.util.CollectionUtils;
-import io.micronaut.http.HttpStatus;
-import io.micronaut.http.MediaType;
-import io.swagger.v3.oas.models.Operation;
-import io.swagger.v3.oas.models.media.ArraySchema;
-import io.swagger.v3.oas.models.media.ComposedSchema;
-import io.swagger.v3.oas.models.media.Schema;
-import io.swagger.v3.oas.models.media.StringSchema;
-import io.swagger.v3.oas.models.responses.ApiResponse;
-import io.swagger.v3.oas.models.servers.Server;
+import java.io.File;
+import java.net.URI;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.time.Period;
+import java.time.ZonedDateTime;
+import java.time.temporal.TemporalAmount;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
 import org.apache.commons.lang3.StringUtils;
-import org.openapitools.codegen.*;
+import org.openapitools.codegen.CliOption;
+import org.openapitools.codegen.CodegenConstants;
+import org.openapitools.codegen.CodegenModel;
+import org.openapitools.codegen.CodegenOperation;
+import org.openapitools.codegen.CodegenParameter;
+import org.openapitools.codegen.CodegenProperty;
+import org.openapitools.codegen.CodegenResponse;
+import org.openapitools.codegen.SpecValidationException;
+import org.openapitools.codegen.SupportingFile;
 import org.openapitools.codegen.languages.features.BeanValidationFeatures;
 import org.openapitools.codegen.languages.features.OptionalFeatures;
 import org.openapitools.codegen.languages.features.UseGenericResponseFeatures;
@@ -19,12 +37,15 @@ import org.openapitools.codegen.utils.ModelUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
-import java.net.URI;
-import java.time.*;
-import java.time.temporal.TemporalAmount;
-import java.util.*;
-import java.util.stream.Collectors;
+import io.micronaut.core.util.CollectionUtils;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.MediaType;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.media.ComposedSchema;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.media.StringSchema;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.servers.Server;
 
 public class MicronautCodegen extends AbstractJavaCodegen
 		implements BeanValidationFeatures, UseGenericResponseFeatures, OptionalFeatures {
@@ -81,7 +102,8 @@ public class MicronautCodegen extends AbstractJavaCodegen
 		cliOptions.add(CliOption.newString(CLIENT_ID, "ClientId to use."));
 		cliOptions.add(CliOption.newBoolean(USE_REFERENCED_SCHEMA_AS_DEFAULT,
 				"Use the referenced schemas type as default values.", useReferencedSchemaAsDefault));
-		cliOptions.add(CliOption.newBoolean(ADDITIONAL_PROPS_COMPOSED, "Support addtional properties with  composed schemas.",
+		cliOptions.add(CliOption.newBoolean(ADDITIONAL_PROPS_COMPOSED,
+				"Support addtional properties with  composed schemas.",
 				supportsAdditionalPropertiesWithComposedSchema));
 
 		// there is no documentation template yet
@@ -102,7 +124,8 @@ public class MicronautCodegen extends AbstractJavaCodegen
 		additionalProperties.put(USE_JAVAX_GENERATED, useJavaxGenerated);
 		additionalProperties.put(USE_LOMBOK_GENERATED, useLombokGenerated);
 		additionalProperties.put(USE_REFERENCED_SCHEMA_AS_DEFAULT, useReferencedSchemaAsDefault);
-		additionalProperties.put(ADDITIONAL_PROPS_COMPOSED, supportsAdditionalPropertiesWithComposedSchema);
+		additionalProperties.put(ADDITIONAL_PROPS_COMPOSED,
+				supportsAdditionalPropertiesWithComposedSchema);
 		additionalProperties.put(CodegenConstants.TEMPLATE_DIR, "Micronaut");
 
 		// add custom type mappings
@@ -188,9 +211,9 @@ public class MicronautCodegen extends AbstractJavaCodegen
 			useReferencedSchemaAsDefault = convertPropertyToBooleanAndWriteBack(USE_REFERENCED_SCHEMA_AS_DEFAULT);
 		}
 		if (additionalProperties.containsKey(ADDITIONAL_PROPS_COMPOSED)) {
-			supportsAdditionalPropertiesWithComposedSchema = convertPropertyToBooleanAndWriteBack(ADDITIONAL_PROPS_COMPOSED);
+			supportsAdditionalPropertiesWithComposedSchema =
+					convertPropertyToBooleanAndWriteBack(ADDITIONAL_PROPS_COMPOSED);
 		}
-
 
 		// we do not generate projects, only api, set source and test folder
 
@@ -325,28 +348,6 @@ public class MicronautCodegen extends AbstractJavaCodegen
 	}
 
 	@Override
-	public String getTypeDeclaration(Schema p) {
-		Schema<?> schema = ModelUtils.unaliasSchema(this.openAPI, p, this.importMapping);
-		Schema<?> target = ModelUtils.isGenerateAliasAsModel() ? p : schema;
-		Schema inner;
-		if (ModelUtils.isArraySchema(target)) {
-			inner = this.getSchemaItems((ArraySchema) schema);
-			return this.getSchemaType(target) + "<" + this.getTypeDeclaration(inner) + ">";
-		} else if (ModelUtils.isMapSchema(target)) {
-			inner = this.getAdditionalProperties(target);
-			if (inner == null) {
-				LOGGER.error("`{}` (map property) does not have a proper inner type defined. Default to type:string", p.getName());
-				inner = (new StringSchema()).description("TODO default missing map inner type to string");
-				p.setAdditionalProperties(inner);
-			}
-
-			return this.getSchemaType(target) + "<String, " + this.getTypeDeclaration(inner) + ">";
-		} else {
-			return super.getTypeDeclaration(target);
-		}
-	}
-
-	@Override
 	public String getSchemaType(Schema schema) {
 		var format = schema.getFormat();
 		if (schema instanceof StringSchema && format != null && CUSTOM_FORMATS.containsKey(format)) {
@@ -388,9 +389,10 @@ public class MicronautCodegen extends AbstractJavaCodegen
 		for (CodegenModel model : allModels.values()) {
 
 			// check id additional properties should be handled through composition and apply the map if so.
-			// see https://github.com/OpenAPITools/openapi-generator/blob/master/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java#L196-L201
 			if (supportsAdditionalPropertiesWithComposedSchema && model.getAdditionalProperties() != null) {
-				model.getVendorExtensions().put("additionalPropertiesMap", String.format("java.util.Map<java.lang.String, %s>", model.getAdditionalProperties().getDataType()));
+				model.getVendorExtensions()
+						.put("additionalPropertiesMap", String.format("java.util.Map<java.lang.String, %s>",
+								model.getAdditionalProperties().getDataType()));
 			}
 
 			var discriminator = model.discriminator;
@@ -402,8 +404,8 @@ public class MicronautCodegen extends AbstractJavaCodegen
 			model.vars.stream()
 					.filter(property -> property.getName().equals(discriminator.getPropertyName()))
 					.findAny().ifPresent(property -> {
-				discriminator.setPropertyType(property.getDataType());
-				model.vars.remove(property);
+								discriminator.setPropertyType(property.getDataType());
+								model.vars.remove(property);
 			});
 
 			// add discriminator value to submodel

--- a/src/main/java/org/openapitools/codegen/languages/MicronautCodegen.java
+++ b/src/main/java/org/openapitools/codegen/languages/MicronautCodegen.java
@@ -152,8 +152,7 @@ public class MicronautCodegen extends AbstractJavaCodegen
 	}
 
 	@Override
-	public void postProcess() {
-	}
+	public void postProcess() {}
 
 	@Override
 	public String getName() {
@@ -389,8 +388,8 @@ public class MicronautCodegen extends AbstractJavaCodegen
 			model.vars.stream()
 					.filter(property -> property.getName().equals(discriminator.getPropertyName()))
 					.findAny().ifPresent(property -> {
-				discriminator.setPropertyType(property.getDataType());
-				model.vars.remove(property);
+								discriminator.setPropertyType(property.getDataType());
+								model.vars.remove(property);
 			});
 
 			// add discriminator value to submodel

--- a/src/main/resources/Micronaut/modelPojo.mustache
+++ b/src/main/resources/Micronaut/modelPojo.mustache
@@ -80,7 +80,7 @@ public {{#discriminator}}abstract {{/discriminator}}class {{classname}}{{#parent
         return additionalProperties;
     }
 
-    @com.fasterxml.jackson.annotation.JsonAnyGetter
+    @com.fasterxml.jackson.annotation.JsonAnySetter
     public void setAdditionalProperties({{{vendorExtensions.additionalPropertiesMap}}} additionalProperties) {
         this.additionalProperties = additionalProperties;
     }

--- a/src/main/resources/Micronaut/modelPojo.mustache
+++ b/src/main/resources/Micronaut/modelPojo.mustache
@@ -72,6 +72,22 @@ public {{#discriminator}}abstract {{/discriminator}}class {{classname}}{{#parent
 	}
 	{{/vars}}
 
+    {{#vendorExtensions.additionalPropertiesMap}}
+    private {{{vendorExtensions.additionalPropertiesMap}}} additionalProperties;
+
+    @com.fasterxml.jackson.annotation.JsonAnyGetter
+    public {{{vendorExtensions.additionalPropertiesMap}}} getAdditionalProperties() {
+        return additionalProperties;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonAnyGetter
+    public void setAdditionalProperties({{{vendorExtensions.additionalPropertiesMap}}} additionalProperties) {
+        this.additionalProperties = additionalProperties;
+    }
+
+    {{/vendorExtensions.additionalPropertiesMap}}
+
+
 	// getter/setter
 	{{#vars}}
 


### PR DESCRIPTION
Add option to use the referenced schema's type as the default for mandatory fields. Without that, there can be situations with incompatible types for the default value and the field value(mostly when using generateAliasAsMode=true).