### PR TITLE
Add type parameter for @Nullable.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,13 +5,13 @@
 	<parent>
 		<groupId>io.kokuwa</groupId>
 		<artifactId>maven-parent</artifactId>
-		<version>0.2.4</version>
+		<version>0.2.5</version>
 		<relativePath />
 	</parent>
 
 	<groupId>io.kokuwa.micronaut</groupId>
 	<artifactId>micronaut-openapi-codegen</artifactId>
-	<version>2.0.3-SNAPSHOT</version>
+	<version>2.1.0-SNAPSHOT</version>
 
 	<name>OpenApi codegen for Micronaut</name>
 	<description>This is an openapi generator for Micronaut.</description>
@@ -48,7 +48,7 @@
 		<!-- ============================= Libaries ============================== -->
 		<!-- ===================================================================== -->
 
-		<version.io.micronaut>2.3.3</version.io.micronaut>
+		<version.io.micronaut>2.4.0</version.io.micronaut>
 		<version.org.openapitools>5.0.1</version.org.openapitools>
 		<version.org.openapitools.jackson.nullable>0.2.1</version.org.openapitools.jackson.nullable>
 

--- a/src/it/custom-types/pom.xml
+++ b/src/it/custom-types/pom.xml
@@ -16,7 +16,11 @@
 		<dependency>
 			<groupId>io.micronaut</groupId>
 			<artifactId>micronaut-http</artifactId>
-			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>javax.annotation</groupId>
+			<artifactId>javax.annotation-api</artifactId>
+			<scope>runtime</scope>
 		</dependency>
 
 	</dependencies>
@@ -33,6 +37,8 @@
 						<typeMapping>UUID=String</typeMapping>
 						<typeMapping>array=java.util.Set</typeMapping>
 						<typeMapping>map=java.util.Dictionary</typeMapping>
+						<typeMapping>Nullable=io.micronaut.core.annotation.Nullable</typeMapping>
+						<typeMapping>Nonnull=io.micronaut.core.annotation.NonNull</typeMapping>
 					</typeMappings>
 					<instantiationTypes>
 						<instantiationType>map=java.util.Hashtable</instantiationType>
@@ -40,6 +46,7 @@
 					</instantiationTypes>
 					<configOptions>
 						<useJavaxGenerated>false</useJavaxGenerated>
+						<useOptional>true</useOptional>
 						<introspected>false</introspected>
 					</configOptions>
 					<generateSupportingFiles>false</generateSupportingFiles>

--- a/src/it/custom-types/src/main/resources/openapi/spec.yaml
+++ b/src/it/custom-types/src/main/resources/openapi/spec.yaml
@@ -2,7 +2,20 @@ openapi: 3.0.2
 info:
   title: Test Spec
   version: '0'
-paths: {}
+paths: 
+  /optional:
+    get:
+      operationId: optional
+      parameters:
+      - name: parameter
+        in: query
+        schema:
+          type: string
+      tags:
+      - parameter
+      responses:
+        204:
+          description: Ok.
 components:
   schemas:
     Model:

--- a/src/main/java/org/openapitools/codegen/languages/MicronautCodegen.java
+++ b/src/main/java/org/openapitools/codegen/languages/MicronautCodegen.java
@@ -152,13 +152,14 @@ public class MicronautCodegen extends AbstractJavaCodegen
 		typeMapping.put("asyncMaybe", "io.reactivex.Maybe");
 		typeMapping.put("asyncFlowable", "io.reactivex.Flowable");
 		typeMapping.put("asyncFileUpload", "io.micronaut.http.multipart.StreamingFileUpload");
+		typeMapping.put("Nullable", javax.annotation.Nullable.class.getName());
+		typeMapping.put("Nonnull", javax.annotation.Nonnull.class.getName());
 		instantiationTypes.put("array", ArrayList.class.getName());
 		instantiationTypes.put("map", HashMap.class.getName());
 	}
 
 	@Override
-	public void postProcess() {
-	}
+	public void postProcess() {}
 
 	@Override
 	public String getName() {
@@ -235,6 +236,11 @@ public class MicronautCodegen extends AbstractJavaCodegen
 		if (dateTimeRelaxed && !openAPI.getPaths().isEmpty()) {
 			addSupportingFile(sourceFolder, invokerPackage, "TimeTypeConverterRegistrar");
 		}
+
+		// add type mappings for mustache
+
+		additionalProperties.put("type.Nullable", typeMapping.get("Nullable"));
+		additionalProperties.put("type.Nonnull", typeMapping.get("Nonnull"));
 	}
 
 	@Override
@@ -404,9 +410,9 @@ public class MicronautCodegen extends AbstractJavaCodegen
 			model.vars.stream()
 					.filter(property -> property.getName().equals(discriminator.getPropertyName()))
 					.findAny().ifPresent(property -> {
-								discriminator.setPropertyType(property.getDataType());
-								model.vars.remove(property);
-			});
+						discriminator.setPropertyType(property.getDataType());
+						model.vars.remove(property);
+					});
 
 			// add discriminator value to submodel
 

--- a/src/main/resources/Micronaut/apiParams.mustache
+++ b/src/main/resources/Micronaut/apiParams.mustache
@@ -11,7 +11,7 @@
 {{/isLong}}{{/isInteger}}{{/maximum}}{{#minLength}}{{^maxLength}}			@javax.validation.constraints.Size(min = {{minLength}})
 {{/maxLength}}{{/minLength}}{{^minLength}}{{#maxLength}}			@javax.validation.constraints.Size(max = {{maxLength}})
 {{/maxLength}}{{/minLength}}{{#minLength}}{{#maxLength}}			@javax.validation.constraints.Size(min = {{minLength}}, max = {{maxLength}})
-{{/maxLength}}{{/minLength}}{{/useBeanValidation}}{{^required}}{{^isBodyParam}}{{^useOptional}}			@javax.annotation.Nullable{{/useOptional}}{{#useOptional}}			@javax.annotation.Nonnull{{/useOptional}}
+{{/maxLength}}{{/minLength}}{{/useBeanValidation}}{{^required}}{{^isBodyParam}}{{^useOptional}}			@{{type.Nullable}}{{/useOptional}}{{#useOptional}}			@{{type.Nonnull}}{{/useOptional}}
 {{/isBodyParam}}{{/required}}{{#isQueryParam}}			@io.micronaut.http.annotation.QueryValue{{^isArray}}(value = "{{baseName}}"{{^isContainer}}{{#defaultValue}}, defaultValue = "{{defaultValue}}"{{/defaultValue}}{{/isContainer}}){{/isArray}}
 {{/isQueryParam}}{{#isFormParam}}			@io.micronaut.http.annotation.Part(value = "{{baseName}}")
 {{/isFormParam}}{{#isBodyParam}}			@io.micronaut.http.annotation.Body

--- a/src/main/resources/Micronaut/api_client.mustache
+++ b/src/main/resources/Micronaut/api_client.mustache
@@ -13,7 +13,7 @@ public interface {{classname}}Client extends {{classname}} {
 	@io.micronaut.http.annotation.Consumes({ {{#consumes}}"{{{mediaType}}}"{{^-last}}, {{/-last}}{{/consumes}} }){{/hasConsumes}}{{#hasProduces}}
 	@io.micronaut.http.annotation.Produces({ {{#produces}}"{{{mediaType}}}"{{^-last}}, {{/-last}}{{/produces}} }){{/hasProduces}}
 	{{>returnType}} {{nickname}}(
-			@javax.annotation.Nullable
+			@{{type.Nullable}}
 			@io.micronaut.http.annotation.Header(io.micronaut.http.HttpHeaders.AUTHORIZATION)
 			String authorization{{#hasParams}},
 {{>apiParams}}{{/hasParams}});

--- a/src/main/resources/Micronaut/testParams.mustache
+++ b/src/main/resources/Micronaut/testParams.mustache
@@ -1,4 +1,4 @@
-{{#allParams}}			@javax.annotation.Nullable
+{{#allParams}}			@{{type.Nullable}}
 {{#isQueryParam}}			@io.micronaut.http.annotation.QueryValue{{^isContainer}}(value = "{{baseName}}"){{/isContainer}}
 {{/isQueryParam}}{{#isBodyParam}}			@io.micronaut.http.annotation.Body
 {{/isBodyParam}}{{#isPathParam}}			@io.micronaut.http.annotation.PathVariable(name = "{{baseName}}")

--- a/src/main/resources/Micronaut/test_client.mustache
+++ b/src/main/resources/Micronaut/test_client.mustache
@@ -17,7 +17,7 @@ public interface {{classname}}TestClient { {{#operations}}{{#operation}}
 	@io.micronaut.http.annotation.Produces({ {{#consumes}}"{{{mediaType}}}"{{^-last}}, {{/-last}}{{/consumes}} }){{/hasConsumes}}{{#hasProduces}}
 	@io.micronaut.http.annotation.Consumes({ {{#produces}}"{{{mediaType}}}"{{^-last}}, {{/-last}}{{/produces}} }){{/hasProduces}}
 	io.micronaut.http.HttpResponse<{{^returnType}}?{{/returnType}}{{#returnType}}{{{returnType}}}{{/returnType}}> {{nickname}}(
-			@javax.annotation.Nullable
+			@{{type.Nullable}}
 			@io.micronaut.http.annotation.Header(io.micronaut.http.HttpHeaders.AUTHORIZATION)
 			String authorization{{#hasParams}},
 {{>testParams}}{{/hasParams}});{{/vendorExtensions.has401}}{{/operation}}


### PR DESCRIPTION
With Micronaut 2.4 custom @Nullable/@Nonnull was introduced to replace jsr305 annotations (see https://github.com/micronaut-projects/micronaut-core/issues/1633).  This commit adds Nullable and NonNull as type parameter, see testcase custom-types.