### PR TITLE
Add some fixes and tests for responses with multiple bodies/contenttypes

### DIFF
--- a/src/it/basic-nongeneric/pom.xml
+++ b/src/it/basic-nongeneric/pom.xml
@@ -10,6 +10,13 @@
 
 	<artifactId>@project.artifactId@-it-basic-nongeneric</artifactId>
 
+	<dependencies>
+		<dependency>
+			<groupId>io.micronaut.xml</groupId>
+			<artifactId>micronaut-jackson-xml</artifactId>
+		</dependency>
+	</dependencies>
+
 	<build>
 		<plugins>
 			<plugin>
@@ -26,6 +33,7 @@
 								<resource>
 									<directory>${project.basedir}/../basic/src/test</directory>
 									<includes>
+										<include>**/MediatypeControllerTest.java</include>
 										<include>**/ResponseControllerTest.java</include>
 										<include>**/application-test.yaml</include>
 										<include>**/logback.xml</include>

--- a/src/it/basic-nongeneric/src/main/java/codegen/MediatypeController.java
+++ b/src/it/basic-nongeneric/src/main/java/codegen/MediatypeController.java
@@ -17,24 +17,23 @@ import io.micronaut.http.multipart.CompletedFileUpload;
 public class MediatypeController implements MediatypeApi {
 
 	@Override
-	public HttpResponse<InlineResponse2001> mediatypePostPlain(String string) {
-		return HttpResponse.ok(new InlineResponse2001().setString(string));
+	public InlineResponse2001 mediatypePostPlain(String string) {
+		return new InlineResponse2001().setString(string);
 	}
 
 	@Override
-	public HttpResponse<InlineResponse2002> mediatypePostOctetStream(byte[] body) {
-		return HttpResponse.ok(new InlineResponse2002().setBinary(body));
+	public InlineResponse2002 mediatypePostOctetStream(byte[] body) {
+		return new InlineResponse2002().setBinary(body);
 	}
 
 	@Override
-	public HttpResponse<InlineResponse2003> mediatypePostMultipart(Integer orderId, Integer userId,
-			CompletedFileUpload fileName) {
+	public InlineResponse2003 mediatypePostMultipart(Integer orderId, Integer userId, CompletedFileUpload fileName) {
 		try {
-			return HttpResponse.ok(new InlineResponse2003()
+			return new InlineResponse2003()
 					.setOrderId(orderId)
 					.setUserId(userId)
 					.setFileName(fileName.getFilename())
-					.setFile(fileName.getBytes()));
+					.setFile(fileName.getBytes());
 		} catch (IOException e) {
 			throw new HttpStatusException(HttpStatus.INTERNAL_SERVER_ERROR, e);
 		}
@@ -49,7 +48,7 @@ public class MediatypeController implements MediatypeApi {
 	}
 
 	@Override
-	public HttpResponse<MediaModel> mediatypeMultipleContentTypesSameModel() {
-		return HttpResponse.ok(new MediaModel().setData("test"));
+	public MediaModel mediatypeMultipleContentTypesSameModel() {
+		return new MediaModel().setData("test");
 	}
 }

--- a/src/it/basic-nongeneric/src/main/java/codegen/ResponseController.java
+++ b/src/it/basic-nongeneric/src/main/java/codegen/ResponseController.java
@@ -33,15 +33,21 @@ class ResponseController implements ResponseApi {
 	}
 
 	@Override
-	public HttpResponse<Object> multiple(Boolean redirect) {
-		if (redirect) {
-			return HttpResponse.status(HttpStatus.MULTIPLE_CHOICES).body(new ResponseMultiple300().setBar(DOUBLE));
-		}
-		return HttpResponse.ok(new ResponseMultiple200().setFoo(STRING));
+	public HttpResponse<ResponseMultiple200> multipleResponseCodes(Boolean redirect) {
+		return redirect
+				? HttpResponse.status(HttpStatus.MULTIPLE_CHOICES).body(new ResponseMultiple200().setFoo(STRING))
+				: HttpResponse.ok(new ResponseMultiple200().setFoo(STRING));
 	}
 
 	@Override
-	public HttpResponse<Object> multipleNotFound(Boolean redirect, Boolean found) {
+	public HttpResponse<Object> multipleDataTypes(Boolean redirect) {
+		return redirect
+				? HttpResponse.status(HttpStatus.MULTIPLE_CHOICES).body(new ResponseMultiple300().setBar(DOUBLE))
+				: HttpResponse.ok(new ResponseMultiple200().setFoo(STRING));
+	}
+
+	@Override
+	public HttpResponse<Object> multipleDataTypesNotFound(Boolean redirect, Boolean found) {
 		if (redirect) {
 			return HttpResponse.status(HttpStatus.MULTIPLE_CHOICES).body(new ResponseMultiple300().setBar(DOUBLE));
 		}

--- a/src/it/basic/pom.xml
+++ b/src/it/basic/pom.xml
@@ -10,6 +10,13 @@
 
 	<artifactId>@project.artifactId@-it-basic</artifactId>
 
+	<dependencies>
+		<dependency>
+			<groupId>io.micronaut.xml</groupId>
+			<artifactId>micronaut-jackson-xml</artifactId>
+		</dependency>
+	</dependencies>
+
 	<build>
 		<plugins>
 			<plugin>

--- a/src/it/basic/src/main/java/codegen/ResponseController.java
+++ b/src/it/basic/src/main/java/codegen/ResponseController.java
@@ -31,7 +31,14 @@ class ResponseController implements ResponseApi {
 	}
 
 	@Override
-	public HttpResponse<Object> multiple(Boolean redirect) {
+	public HttpResponse<ResponseMultiple200> multipleResponseCodes(Boolean redirect) {
+		return redirect
+				? HttpResponse.status(HttpStatus.MULTIPLE_CHOICES).body(new ResponseMultiple200().setFoo(STRING))
+				: HttpResponse.ok(new ResponseMultiple200().setFoo(STRING));
+	}
+
+	@Override
+	public HttpResponse<Object> multipleDataTypes(Boolean redirect) {
 		if (redirect) {
 			return HttpResponse.status(HttpStatus.MULTIPLE_CHOICES).body(new ResponseMultiple300().setBar(DOUBLE));
 		}
@@ -39,7 +46,7 @@ class ResponseController implements ResponseApi {
 	}
 
 	@Override
-	public HttpResponse<Object> multipleNotFound(Boolean redirect, Boolean found) {
+	public HttpResponse<Object> multipleDataTypesNotFound(Boolean redirect, Boolean found) {
 		if (redirect) {
 			return HttpResponse.status(HttpStatus.MULTIPLE_CHOICES).body(new ResponseMultiple300().setBar(DOUBLE));
 		}

--- a/src/it/basic/src/main/resources/openapi/spec.yaml
+++ b/src/it/basic/src/main/resources/openapi/spec.yaml
@@ -109,9 +109,33 @@ paths:
                   type: string
         404:
           description: Ok.
-  /response/multiple:
+  /response/multiple-response-codes:
     get:
-      operationId: multiple
+      operationId: multipleResponseCodes
+      parameters:
+      - name: redirect
+        in: query
+        required: true
+        schema:
+          type: boolean
+      tags:
+      - response
+      responses:
+        200:
+          description: Ok.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseMultiple200'
+        300:
+          description: Ok.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseMultiple200'
+  /response/multiple-datatypes:
+    get:
+      operationId: multipleDataTypes
       parameters:
       - name: redirect
         in: query
@@ -133,9 +157,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ResponseMultiple300'
-  /response/multiple-notfound:
+  /response/multiple-datatypes-notfound:
     get:
-      operationId: multipleNotFound
+      operationId: multipleDataTypesNotFound
       parameters:
       - name: redirect
         in: query
@@ -525,9 +549,9 @@ paths:
                 - userId
                 - fileName
                 - file
-  /mediatype/multiple-contenttypes:
-    post:
-      operationId: mediatypeMultipleContentTypes
+  /mediatype/multiple-contenttypes-with-different-model:
+    get:
+      operationId: mediatypeMultipleContentTypesDifferentModel
       tags:
       - mediatype
       parameters:
@@ -542,13 +566,25 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties: 
-                  value:
-                    type: string
+                $ref: '#/components/schemas/MediaModel'
             text/plain:
               schema:
                 type: string
+  /mediatype/multiple-contenttypes-with-same-model:
+    get:
+      operationId: mediatypeMultipleContentTypesSameModel
+      tags:
+      - mediatype
+      responses:
+        200:
+          description: Ok.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MediaModel'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/MediaModel'
 components:
   schemas:
     StringEnumeration:
@@ -728,3 +764,8 @@ components:
       properties:
         bar: 
           type: number
+    MediaModel:
+      type: object
+      properties:
+        data: 
+          type: string

--- a/src/it/basic/src/test/java/codegen/MediatypeControllerTest.java
+++ b/src/it/basic/src/test/java/codegen/MediatypeControllerTest.java
@@ -12,7 +12,8 @@ import org.junit.jupiter.api.Test;
 import codegen.model.InlineResponse2001;
 import codegen.model.InlineResponse2002;
 import codegen.model.InlineResponse2003;
-import codegen.model.InlineResponse2004;
+import codegen.model.MediaModel;
+import io.micronaut.http.HttpHeaders;
 import io.micronaut.http.HttpMethod;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.MediaType;
@@ -67,17 +68,39 @@ public class MediatypeControllerTest implements MediatypeApiTestSpec {
 
 	@Test
 	@Override
-	public void mediatypeMultipleContentTypes200() {
-		var response = client.mediatypeMultipleContentTypes(false);
+	public void mediatypeMultipleContentTypesDifferentModel200() {
+		var response = client.mediatypeMultipleContentTypesDifferentModel(false);
 		assertEquals(MediaType.APPLICATION_JSON_TYPE, response.getContentType().orElse(null), "type");
-		assertEquals(new InlineResponse2004().setValue("json"),
-				response.getBody(InlineResponse2004.class).orElse(null), "body");
+		assertEquals(new MediaModel().setData("json"), response.getBody(MediaModel.class).orElse(null), "body");
 	}
 
 	@Test
-	public void mediatypeMultipleContentTypes200Plain() {
-		var response = client.mediatypeMultipleContentTypes(true);
+	public void mediatypeMultipleContentTypesDifferentModel200Plain() {
+		var response = client.mediatypeMultipleContentTypesDifferentModel(true);
 		assertEquals(MediaType.TEXT_PLAIN_TYPE, response.getContentType().orElse(null), "type");
 		assertEquals("plain", response.getBody(String.class).orElse(null), "body");
+	}
+
+	@Test
+	@Override
+	public void mediatypeMultipleContentTypesSameModel200() {
+		var request = HttpRequest
+				.GET("/mediatype/multiple-contenttypes-with-same-model")
+				.accept(MediaType.APPLICATION_JSON);
+		var response = HttpResponseAssertions
+				.assert200(() -> rawClient.toBlocking().exchange(request, MediaModel.class));
+		assertEquals(MediaType.APPLICATION_JSON, response.header(HttpHeaders.CONTENT_TYPE));
+		assertEquals(new MediaModel().setData("test"), response.body());
+	}
+
+	@Test
+	public void mediatypeMultipleContentTypesSameModel200Xml() {
+		var request = HttpRequest
+				.GET("/mediatype/multiple-contenttypes-with-same-model")
+				.accept(MediaType.APPLICATION_XML);
+		var response = HttpResponseAssertions
+				.assert200(() -> rawClient.toBlocking().exchange(request, MediaModel.class));
+		assertEquals(MediaType.APPLICATION_XML, response.header(HttpHeaders.CONTENT_TYPE));
+		assertEquals(new MediaModel().setData("test"), response.body());
 	}
 }

--- a/src/it/basic/src/test/java/codegen/ResponseControllerTest.java
+++ b/src/it/basic/src/test/java/codegen/ResponseControllerTest.java
@@ -44,8 +44,22 @@ class ResponseControllerTest implements ResponseApiTestSpec {
 
 	@Test
 	@Override
-	public void multiple200() {
-		var response = assert200(() -> client.multiple(false));
+	public void multipleResponseCodes200() {
+		var response = assert200(() -> client.multipleResponseCodes(false));
+		assertEquals(new ResponseMultiple200().setFoo(ResponseController.STRING), response.body());
+	}
+
+	@Test
+	@Override
+	public void multipleResponseCodes300() {
+		var response = assert300(() -> client.multipleResponseCodes(true));
+		assertEquals(new ResponseMultiple200().setFoo(ResponseController.STRING), response.body());
+	}
+
+	@Test
+	@Override
+	public void multipleDataTypes200() {
+		var response = assert200(() -> client.multipleDataTypes(false));
 		assertEquals(
 				new ResponseMultiple200().setFoo(ResponseController.STRING),
 				response.getBody(ResponseMultiple200.class).orElse(null));
@@ -53,8 +67,8 @@ class ResponseControllerTest implements ResponseApiTestSpec {
 
 	@Test
 	@Override
-	public void multiple300() {
-		var response = assert300(() -> client.multiple(true));
+	public void multipleDataTypes300() {
+		var response = assert300(() -> client.multipleDataTypes(true));
 		assertEquals(
 				new ResponseMultiple300().setBar(ResponseController.DOUBLE),
 				response.getBody(ResponseMultiple300.class).orElse(null));
@@ -62,8 +76,8 @@ class ResponseControllerTest implements ResponseApiTestSpec {
 
 	@Test
 	@Override
-	public void multipleNotFound200() {
-		var response = assert200(() -> client.multipleNotFound(false, true));
+	public void multipleDataTypesNotFound200() {
+		var response = assert200(() -> client.multipleDataTypesNotFound(false, true));
 		assertEquals(
 				new ResponseMultiple200().setFoo(ResponseController.STRING),
 				response.getBody(ResponseMultiple200.class).orElse(null));
@@ -71,8 +85,8 @@ class ResponseControllerTest implements ResponseApiTestSpec {
 
 	@Test
 	@Override
-	public void multipleNotFound300() {
-		var response = assert300(() -> client.multipleNotFound(true, true));
+	public void multipleDataTypesNotFound300() {
+		var response = assert300(() -> client.multipleDataTypesNotFound(true, true));
 		assertEquals(
 				new ResponseMultiple300().setBar(ResponseController.DOUBLE),
 				response.getBody(ResponseMultiple300.class).orElse(null));
@@ -80,8 +94,8 @@ class ResponseControllerTest implements ResponseApiTestSpec {
 
 	@Test
 	@Override
-	public void multipleNotFound404() {
-		assert404(() -> client.multipleNotFound(false, false));
+	public void multipleDataTypesNotFound404() {
+		assert404(() -> client.multipleDataTypesNotFound(false, false));
 	}
 
 	@Test


### PR DESCRIPTION
Fixed handling for:
 * response with multiple mediatypes but same model (xml vs. json)
 * response with multiple status codes but same model

Mitigates #60 