### PR TITLE
Fix enum classes in native image, annotate as Introspected

### DIFF
--- a/src/it/basic/src/test/java/codegen/model/ModelTest.java
+++ b/src/it/basic/src/test/java/codegen/model/ModelTest.java
@@ -70,6 +70,12 @@ class ModelTest {
 	}
 
 	@Test
+	@DisplayName("model enum: introspected present by default")
+	void modelEnumIntrospected() {
+		assertNotNull(StringEnumeration.class.getAnnotation(Introspected.class), "no annotation found");
+	}
+
+	@Test
 	@DisplayName("model enum: constants")
 	void modelEnumConstants() {
 		assertEquals(StringEnumeration.ONE.getValue(), StringEnumeration.ONE_VALUE);
@@ -90,6 +96,12 @@ class ModelTest {
 		assertEquals(Optional.of(StringEnumeration.ONE), StringEnumeration.toOptional(StringEnumeration.ONE_VALUE));
 		assertEquals(Optional.of(StringEnumeration.TWO), StringEnumeration.toOptional(StringEnumeration.TWO_VALUE));
 		assertEquals(Optional.empty(), StringEnumeration.toOptional("meh"));
+	}
+
+	@Test
+	@DisplayName("embedded enum: introspected present by default")
+	void embeddedEnumIntrospected() {
+		assertNotNull(EmbeddedEnumeration.class.getAnnotation(Introspected.class), "no annotation found");
 	}
 
 	@Test

--- a/src/main/resources/Micronaut/modelEnum.mustache
+++ b/src/main/resources/Micronaut/modelEnum.mustache
@@ -1,3 +1,5 @@
+{{#introspected}}@io.micronaut.core.annotation.Introspected
+{{/introspected}}
 public enum {{#nameInCamelCase}}{{{nameInCamelCase}}}{{/nameInCamelCase}}{{^nameInCamelCase}}{{{classname}}}{{/nameInCamelCase}} {
 
 {{#allowableValues}}{{#enumVars}}	{{{name}}}({{{value}}}){{^-last}},


### PR DESCRIPTION
Model classes are annotated as Introspected in order to generate the
appropriate metadata for Micronaut and the GraalVM native image
compiler. This isn't the case for enum classes, which isn't a problem
for Micronaut running in a standard JVM but results in errors when used
in a GraalVM native image.

By annotating enum classes as Introspected they can be used in both a
standard JVM and in a GraalVM native image.