### PR TITLE
Support adding items to a list or map. Fixes #64

### DIFF
--- a/src/it/basic-jackson-databind-nullable/src/test/java/codegen/model/ModelTest.java
+++ b/src/it/basic-jackson-databind-nullable/src/test/java/codegen/model/ModelTest.java
@@ -6,12 +6,18 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 class ModelTest {
 
-	final Model model = new Model();
+	Model model;
+
+	@BeforeEach
+	void beforeEach() {
+		model = new Model();
+	}
 
 	@Test
 	@DisplayName("non nullable string without default value")
@@ -49,4 +55,13 @@ class ModelTest {
 	void nullableArray() {
 		assertFalse(model.getNullableArray().isPresent());
 	}
+
+	@Test
+	@DisplayName("nullable array add single item")
+	void nullableArrayAddSingleItem() {
+		assertFalse(model.getNullableArray().isPresent());
+		model.addNullableArrayItem("item");
+		assertTrue(model.getNullableArray().isPresent());
+	}
+
 }

--- a/src/main/resources/Micronaut/modelPojo.mustache
+++ b/src/main/resources/Micronaut/modelPojo.mustache
@@ -100,7 +100,42 @@ public {{#discriminator}}abstract {{/discriminator}}class {{classname}}{{#parent
 	public {{classname}} {{setter}}({{>modelPropertyType}} {{name}}) {
 		this.{{name}} = {{name}};
 		return this;
-	}{{/vars}}{{#vars}}{{#isEnum}}
+	}
+
+    {{#isContainer}}
+	public {{classname}} {{#isArray}}add{{/isArray}}{{#isMap}}put{{/isMap}}{{nameInCamelCase}}Item({{#isMap}}String key, {{/isMap}}{{{items.datatypeWithEnum}}} {{name}}Item) {
+		{{#isNullable}}
+			{{#jacksonDatabindNullable}}
+		if (this.{{name}} == null || !this.{{name}}.isPresent()) {
+			this.{{name}} = org.openapitools.jackson.nullable.JsonNullable.<{{{datatypeWithEnum}}}>of({{{defaultValue}}});
+		}
+		try {
+			this.{{name}}.get().{{#isArray}}add({{/isArray}}{{#isMap}}put(key, {{/isMap}}{{name}}Item);
+		} catch (java.util.NoSuchElementException e) {
+			// this can never happen, as we make sure above that the value is present
+		}
+			{{/jacksonDatabindNullable}}
+			{{^jacksonDatabindNullable}}
+		if (this.{{name}} == null) {
+			this.{{name}} = {{{defaultValue}}};
+		}
+		this.{{name}}.{{#isArray}}add({{/isArray}}{{#isMap}}put(key, {{/isMap}}{{name}}Item);
+			{{/jacksonDatabindNullable}}
+		{{/isNullable}}
+		{{^isNullable}}
+			{{^jacksonDatabindNullable}}
+		if (this.{{name}} == null) {
+			this.{{name}} = {{{defaultValue}}};
+		}
+		this.{{name}}.{{#isArray}}add({{/isArray}}{{#isMap}}put(key, {{/isMap}}{{name}}Item);
+			{{/jacksonDatabindNullable}}
+		{{/isNullable}}
+		return this;
+	}
+
+	{{/isContainer}}
+    {{/vars}}
+    {{#vars}}{{#isEnum}}
 
 {{>modelEnum}}{{/isEnum}}{{/vars}}
 }


### PR DESCRIPTION
List and maps are initialized with null which makes it cumbersome to add
items programmatically because of the mandatory null checks.

By adding a specific method for adding an item to a list or a map,
similar to how is done for the native Java generator, the null checks
are no longer required.