### PR TITLE
Generate visitor for subtypes with a discriminator

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,11 @@
  * useGenericResponse: return generic container or specific model, e.g. `Model` vs. `HttpResponse<Model>` (default `true`)
  * useOptional: optional parameters are generated as `java.util.Optional` (default `true`)
  * useJavaxGenerated: add `@javax.annotation.processing.Generated` to all classes (default `true`)
- * useLombokGenerated: add `@lombok.Generated` to all classes (default `false`), usefull for [jacoco](https://github.com/jacoco/jacoco/pull/731)
+ * useLombokGenerated: add `@lombok.Generated` to all classes (default `false`), useful for [jacoco](https://github.com/jacoco/jacoco/pull/731)
  * jacksonDatabindNullable: add container `JsonNullable` to model objects that are nullable (default `true`)
  * supportAsync: use reactivex return types, see [Reactive HTTP Request Processing](https://docs.micronaut.io/2.1.3/guide/index.html#reactiveServer)
- * useReferencedSchemaAsDefault: use the referenced schema's type for instantiation of default values 
+ * useReferencedSchemaAsDefault: use the referenced schema's type for instantiation of default values
+ * visitable: generate visitor for subtypes with a discriminator (default `true`)
 
 ### Null handling and default values
 

--- a/src/it/basic/src/test/java/codegen/model/ModelTest.java
+++ b/src/it/basic/src/test/java/codegen/model/ModelTest.java
@@ -64,6 +64,12 @@ class ModelTest {
 	}
 
 	@Test
+	@DisplayName("inheritance: has visitor")
+	void inheritanceHasVisitor() throws ReflectiveOperationException {
+		assertNotNull(InheritanceModel.class.getDeclaredMethod("accept", InheritanceModel.Visitor.class), "model doesn't accept visitor");
+	}
+
+	@Test
 	@DisplayName("introspected: present by default")
 	void introspected() {
 		assertNotNull(Model.class.getAnnotation(Introspected.class), "no annotation found");

--- a/src/main/java/org/openapitools/codegen/languages/MicronautCodegen.java
+++ b/src/main/java/org/openapitools/codegen/languages/MicronautCodegen.java
@@ -58,6 +58,7 @@ public class MicronautCodegen extends AbstractJavaCodegen
 	public static final String USE_LOMBOK_GENERATED = "useLombokGenerated";
 	public static final String ADDITIONAL_PROPS_COMPOSED = "supportsAdditionalPropertiesWithComposedSchema";
 	public static final String USE_REFERENCED_SCHEMA_AS_DEFAULT = "useReferencedSchemaAsDefault";
+	public static final String VISITABLE = "visitable";
 
 	public static final Map<String, Class<?>> CUSTOM_FORMATS = Map.of(
 			"temporal-amount", TemporalAmount.class,
@@ -84,6 +85,7 @@ public class MicronautCodegen extends AbstractJavaCodegen
 	private boolean useJavaxGenerated = true;
 	private boolean useLombokGenerated = false;
 	private boolean useReferencedSchemaAsDefault = false;
+	private boolean visitable = true;
 
 	public MicronautCodegen() {
 
@@ -102,6 +104,8 @@ public class MicronautCodegen extends AbstractJavaCodegen
 		cliOptions.add(CliOption.newString(CLIENT_ID, "ClientId to use."));
 		cliOptions.add(CliOption.newBoolean(USE_REFERENCED_SCHEMA_AS_DEFAULT,
 				"Use the referenced schemas type as default values.", useReferencedSchemaAsDefault));
+		cliOptions.add(CliOption.newBoolean(VISITABLE,
+				"Generate visitor for subtypes with a discriminator.", visitable));
 		cliOptions.add(CliOption.newBoolean(ADDITIONAL_PROPS_COMPOSED,
 				"Support addtional properties with  composed schemas.",
 				supportsAdditionalPropertiesWithComposedSchema));
@@ -124,6 +128,7 @@ public class MicronautCodegen extends AbstractJavaCodegen
 		additionalProperties.put(USE_JAVAX_GENERATED, useJavaxGenerated);
 		additionalProperties.put(USE_LOMBOK_GENERATED, useLombokGenerated);
 		additionalProperties.put(USE_REFERENCED_SCHEMA_AS_DEFAULT, useReferencedSchemaAsDefault);
+		additionalProperties.put(VISITABLE, visitable);
 		additionalProperties.put(ADDITIONAL_PROPS_COMPOSED,
 				supportsAdditionalPropertiesWithComposedSchema);
 		additionalProperties.put(CodegenConstants.TEMPLATE_DIR, "Micronaut");
@@ -210,6 +215,9 @@ public class MicronautCodegen extends AbstractJavaCodegen
 
 		if (additionalProperties.containsKey(USE_REFERENCED_SCHEMA_AS_DEFAULT)) {
 			useReferencedSchemaAsDefault = convertPropertyToBooleanAndWriteBack(USE_REFERENCED_SCHEMA_AS_DEFAULT);
+		}
+		if (additionalProperties.containsKey(VISITABLE)) {
+			visitable = convertPropertyToBooleanAndWriteBack(VISITABLE);
 		}
 		if (additionalProperties.containsKey(ADDITIONAL_PROPS_COMPOSED)) {
 			supportsAdditionalPropertiesWithComposedSchema =

--- a/src/main/resources/Micronaut/modelPojo.mustache
+++ b/src/main/resources/Micronaut/modelPojo.mustache
@@ -136,6 +136,7 @@ public {{#discriminator}}abstract {{/discriminator}}class {{classname}}{{#parent
 	{{/isContainer}}
     {{/vars}}
 
+    {{#visitable}}
     {{#discriminator}}
     /**
      * Accept the visitor and invoke it for the specific {{classname}} type.
@@ -166,6 +167,7 @@ public {{#discriminator}}abstract {{/discriminator}}class {{classname}}{{#parent
     }
         {{/interfaces.0}}
     {{/parent}}
+    {{/visitable}}
 
     {{#vars}}{{#isEnum}}
 

--- a/src/main/resources/Micronaut/modelPojo.mustache
+++ b/src/main/resources/Micronaut/modelPojo.mustache
@@ -135,6 +135,38 @@ public {{#discriminator}}abstract {{/discriminator}}class {{classname}}{{#parent
 
 	{{/isContainer}}
     {{/vars}}
+
+    {{#discriminator}}
+    /**
+     * Accept the visitor and invoke it for the specific {{classname}} type.
+     *
+     * @param visitor the {{classname}} visitor
+     * @param <T> the return type of the visitor
+     * @return the result from the visitor
+     */
+    public abstract <T> T accept(Visitor<T> visitor);
+
+    /**
+     * A {{classname}} visitor implementation allows visiting the various {{classname}} types.
+     *
+     * @param <R> the return type of the visitor
+     */
+    public interface Visitor<R> {
+        {{#discriminator.mappedModels}}
+        public R visit{{modelName}}({{modelName}} value);
+        {{/discriminator.mappedModels}}
+    }
+    {{/discriminator}}
+
+    {{#parent}}
+        {{#interfaces.0}}
+    @Override
+    public <T> T accept({{{parent}}}.Visitor<T> visitor) {
+        return visitor.visit{{classname}}(this);
+    }
+        {{/interfaces.0}}
+    {{/parent}}
+
     {{#vars}}{{#isEnum}}
 
 {{>modelEnum}}{{/isEnum}}{{/vars}}


### PR DESCRIPTION
When types which extend a common type and are distinguished based on a
discriminator are consumed they are often cast to their specific Java
type which results in error prone boilerplate code.

By generating a visitor for those kind of types the various subtypes can
be consumed in a type safe manner.