### PR TITLE
fix handling for sets and array instantiation.

### DIFF
--- a/src/it/basic/src/main/resources/openapi/spec.yaml
+++ b/src/it/basic/src/main/resources/openapi/spec.yaml
@@ -699,6 +699,8 @@ components:
           type: string
           default: defaultNullableValue
           nullable: true
+        setModel:
+          $ref: '#/components/schemas/SetModel'
     InheritanceModel:
       discriminator:
         propertyName: type
@@ -794,3 +796,8 @@ components:
       properties:
         data: 
           type: string
+    SetModel:
+      type: array
+      items:
+        type: string
+      uniqueItems: true

--- a/src/it/basic/src/test/java/codegen/model/ModelTest.java
+++ b/src/it/basic/src/test/java/codegen/model/ModelTest.java
@@ -8,6 +8,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Set;
+import java.util.HashSet;
+
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -194,5 +197,13 @@ class ModelTest {
 	@DisplayName("model: any type")
 	void modelAny() throws ReflectiveOperationException {
 		assertEquals(Object.class, Model.class.getDeclaredField("any").getType());
+	}
+
+	@Test
+	@DisplayName("model: set type")
+	void modelSet() throws ReflectiveOperationException {
+		assertEquals(Set.class, Model.class.getDeclaredField("setModel").getType());
+		var model = new Model().addSetModelItem("test");
+		assertTrue(model.getSetModel() instanceof HashSet, "The model should be instantiated to HashSet.");
 	}
 }

--- a/src/it/basic/src/test/java/codegen/model/ModelTest.java
+++ b/src/it/basic/src/test/java/codegen/model/ModelTest.java
@@ -9,7 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.IOException;
 import java.util.List;
 import java.util.Set;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -204,6 +204,6 @@ class ModelTest {
 	void modelSet() throws ReflectiveOperationException {
 		assertEquals(Set.class, Model.class.getDeclaredField("setModel").getType());
 		var model = new Model().addSetModelItem("test");
-		assertTrue(model.getSetModel() instanceof HashSet, "The model should be instantiated to HashSet.");
-	}
+		assertTrue(model.getSetModel() instanceof LinkedHashSet, "The model should be instantiated to HashSet.");
+	}HashSet
 }

--- a/src/it/basic/src/test/java/codegen/model/ModelTest.java
+++ b/src/it/basic/src/test/java/codegen/model/ModelTest.java
@@ -205,5 +205,5 @@ class ModelTest {
 		assertEquals(Set.class, Model.class.getDeclaredField("setModel").getType());
 		var model = new Model().addSetModelItem("test");
 		assertTrue(model.getSetModel() instanceof LinkedHashSet, "The model should be instantiated to HashSet.");
-	}HashSet
+	}
 }

--- a/src/main/java/org/openapitools/codegen/languages/MicronautCodegen.java
+++ b/src/main/java/org/openapitools/codegen/languages/MicronautCodegen.java
@@ -14,7 +14,7 @@ import java.time.ZonedDateTime;
 import java.time.temporal.TemporalAmount;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -160,7 +160,7 @@ public class MicronautCodegen extends AbstractJavaCodegen
 		typeMapping.put("Nonnull", javax.annotation.Nonnull.class.getName());
 		instantiationTypes.put("array", ArrayList.class.getName());
 		instantiationTypes.put("map", HashMap.class.getName());
-		instantiationTypes.put("set", HashSet.class.getName());
+		instantiationTypes.put("set", LinkedHashSet.class.getName());
 	}
 
 	@Override

--- a/src/main/java/org/openapitools/codegen/languages/MicronautCodegen.java
+++ b/src/main/java/org/openapitools/codegen/languages/MicronautCodegen.java
@@ -14,9 +14,11 @@ import java.time.ZonedDateTime;
 import java.time.temporal.TemporalAmount;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -41,6 +43,7 @@ import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.http.HttpStatus;
 import io.micronaut.http.MediaType;
 import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.media.ArraySchema;
 import io.swagger.v3.oas.models.media.ComposedSchema;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.media.StringSchema;
@@ -134,6 +137,7 @@ public class MicronautCodegen extends AbstractJavaCodegen
 		typeMapping.put("DateTime", Instant.class.getName());
 		typeMapping.put("array", List.class.getName());
 		typeMapping.put("map", Map.class.getName());
+		typeMapping.put("set", Set.class.getName());
 		typeMapping.put("boolean", Boolean.class.getName());
 		typeMapping.put("string", String.class.getName());
 		typeMapping.put("int", Integer.class.getName());
@@ -156,6 +160,7 @@ public class MicronautCodegen extends AbstractJavaCodegen
 		typeMapping.put("Nonnull", javax.annotation.Nonnull.class.getName());
 		instantiationTypes.put("array", ArrayList.class.getName());
 		instantiationTypes.put("map", HashMap.class.getName());
+		instantiationTypes.put("set", HashSet.class.getName());
 	}
 
 	@Override
@@ -405,8 +410,15 @@ public class MicronautCodegen extends AbstractJavaCodegen
 			return "new " + getSchemaType(schema) + "()";
 		}
 
+		if (ModelUtils.isSet(schema)) {
+			ArraySchema arraySchema = (ArraySchema) schema;
+			String itemType = Optional.ofNullable(arraySchema.getItems()).map(this::getSchemaType).orElse("");
+			return "new " + instantiationTypes.get("set") + "<" + itemType + ">()";
+		}
 		if (ModelUtils.isArraySchema(schema)) {
-			return "new " + instantiationTypes.get("array") + "<>()";
+			ArraySchema arraySchema = (ArraySchema) schema;
+			String itemType = Optional.ofNullable(arraySchema.getItems()).map(this::getSchemaType).orElse("");
+			return "new " + instantiationTypes.get("array") + "<" + itemType + ">()";
 		}
 		if (ModelUtils.isMapSchema(schema)) {
 			return "new " + instantiationTypes.get("map") + "<>()";


### PR DESCRIPTION
* Arrays with ```uniqueItems: true``` will be instantiated to HashSet. They where instantiated to ArrayList before, leading to an incompatible type error. 
* Sets and Arrays will be typed with there item type, if present.