### PR TITLE
use `@Valid` annotation on containers without JsonNullable

### DIFF
--- a/src/it/basic/src/main/resources/openapi/spec.yaml
+++ b/src/it/basic/src/main/resources/openapi/spec.yaml
@@ -617,6 +617,7 @@ components:
       properties:
         someString:
           type: string
+          maxLength: 5
         someInt:
           type: integer
     StringEnumeration:
@@ -648,6 +649,7 @@ components:
       required:
         - name
         - array
+        - requiredObjArray
         - map
         - set
       properties:
@@ -685,6 +687,10 @@ components:
           type: string
           additionalProperties:
             type: string
+        requiredObjArray:
+          type: array
+          items:
+            $ref: '#/components/schemas/SimpleObject'
         optionalArray:
           type: array
           items:

--- a/src/it/validation-jackson-databind-nullable/src/test/java/codegen/NullableValidationTest.java
+++ b/src/it/validation-jackson-databind-nullable/src/test/java/codegen/NullableValidationTest.java
@@ -27,9 +27,27 @@ class NullableValidationTest {
 	}
 
 	@Test
+	@DisplayName("client side validation without JsonNullable")
+	public void nonNullObjectValidation() {
+		assert200(() -> validatingClient.create(new Model()
+				.name("validation test")
+				.addRequiredObjArrayItem(new SimpleObject()
+						.someString("fit"))));
+	}
+
+	@Test
 	@DisplayName("client side validation failure with JsonNullable")
 	public void nullableObjectValidationViolation() {
 		assertThrows(ConstraintViolationException.class, () -> validatingClient.create(new Model()
 				.name("1234567890123456789012345678901234567890"))); // length violation
+	}
+
+	@Test
+	@DisplayName("client side validation failure without JsonNullable")
+	public void nonNullObjectValidationViolation() {
+		assertThrows(ConstraintViolationException.class, () -> validatingClient.create(new Model()
+				.name("is required")
+				.addRequiredObjArrayItem(new SimpleObject()
+						.someString("does not fit")))); // length violation
 	}
 }

--- a/src/main/resources/Micronaut/modelPropertyValidation.mustache
+++ b/src/main/resources/Micronaut/modelPropertyValidation.mustache
@@ -1,5 +1,6 @@
 {{#isModel}}	@javax.validation.Valid
-{{/isModel}}{{#isContainer}}{{#mostInnerItems.isModel}}{{^isNullable}}{{^jacksonDatabindNullable}}	@javax.validation.Valid
+{{/isModel}}{{#isContainer}}{{#mostInnerItems.isModel}}{{^isNullable}}	@javax.validation.Valid
+{{/isNullable}}{{#isNullable}}{{^jacksonDatabindNullable}}	@javax.validation.Valid
 {{/jacksonDatabindNullable}}{{/isNullable}}{{/mostInnerItems.isModel}}{{/isContainer}}{{#required}}{{^isNullable}}	@javax.validation.constraints.NotNull
 {{/isNullable}}{{/required}}{{#pattern}}	@javax.validation.constraints.Pattern(regexp = "{{{pattern}}}")
 {{/pattern}}{{#minimum}}	@javax.validation.constraints.{{#isDouble}}DecimalMin("{{minimum}}"){{/isDouble}}{{#isFloat}}DecimalMin("{{minimum}}"){{/isFloat}}{{^isFloat}}{{^isDouble}}Min({{minimum}}){{/isDouble}}{{/isFloat}}


### PR DESCRIPTION
A mistake in a previous commit caused missing `@Valid` annotations on
container attributes that are not encapsulated in `JsonNullable`. Now
the `@Valid` annotation is always present when there is no
`JsonNullable`.