### PR TITLE
Allow jackson annotations to be set at methods instead of fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 * useReferencedSchemaAsDefault: use the referenced schema's type for instantiation of default values
 * visitable: generate visitor for subtypes with a discriminator (default `true`)
 * pagable: generate provider for pagable (default `false`)
+* annotateMethods: when jackson-annotations should be applied to methods instead of fields (default `false`)
 
 ### Null handling and default values
 

--- a/src/it/annotated-methods/pom.xml
+++ b/src/it/annotated-methods/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>@project.groupId@</groupId>
+		<artifactId>@project.artifactId@-it</artifactId>
+		<version>LOCAL-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>@project.artifactId@-annotated-methods</artifactId>
+
+	<dependencies>
+
+		<!-- micronaut -->
+		<dependency>
+			<groupId>io.micronaut</groupId>
+			<artifactId>micronaut-http</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.openapitools</groupId>
+				<artifactId>openapi-generator-maven-plugin</artifactId>
+				<configuration>
+					<generateAliasAsModel>true</generateAliasAsModel>
+					<configOptions>
+						<annotateMethods>true</annotateMethods>
+						<introspected>false</introspected>
+					</configOptions>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/src/it/annotated-methods/src/main/resources/openapi/spec.yaml
+++ b/src/it/annotated-methods/src/main/resources/openapi/spec.yaml
@@ -1,0 +1,14 @@
+openapi: 3.0.2
+info:
+  title: Test Spec
+  version: '0'
+paths: {}
+components:
+  schemas:
+    Entity:
+      type: object
+      properties:
+        id:
+          type: string
+        isEntity:
+          type: boolean

--- a/src/it/annotated-methods/src/test/java/codegen/ModelTest.java
+++ b/src/it/annotated-methods/src/test/java/codegen/ModelTest.java
@@ -1,0 +1,23 @@
+package codegen;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+class ModelTest {
+
+	@Test
+	void defaultType() throws Exception {
+		ObjectMapper objectMapper = new ObjectMapper();
+		Entity entity = new Entity();
+		entity.setId("my-id");
+		entity.isEntity(true);
+		String entityString = objectMapper.writeValueAsString(entity);
+		String expectedJson = "{\"id\":\"my-id\",\"isEntity\":true}";
+
+		assertEquals(expectedJson, entityString, "The json should keep the defined field names.");
+	}
+}

--- a/src/main/java/org/openapitools/codegen/languages/MicronautCodegen.java
+++ b/src/main/java/org/openapitools/codegen/languages/MicronautCodegen.java
@@ -1,31 +1,5 @@
 package org.openapitools.codegen.languages;
 
-import io.micronaut.core.util.CollectionUtils;
-import io.micronaut.http.HttpStatus;
-import io.micronaut.http.MediaType;
-import io.swagger.v3.oas.models.Operation;
-import io.swagger.v3.oas.models.media.ComposedSchema;
-import io.swagger.v3.oas.models.media.Schema;
-import io.swagger.v3.oas.models.media.StringSchema;
-import io.swagger.v3.oas.models.responses.ApiResponse;
-import io.swagger.v3.oas.models.servers.Server;
-import org.apache.commons.lang3.StringUtils;
-import org.openapitools.codegen.CliOption;
-import org.openapitools.codegen.CodegenConstants;
-import org.openapitools.codegen.CodegenModel;
-import org.openapitools.codegen.CodegenOperation;
-import org.openapitools.codegen.CodegenParameter;
-import org.openapitools.codegen.CodegenProperty;
-import org.openapitools.codegen.CodegenResponse;
-import org.openapitools.codegen.SpecValidationException;
-import org.openapitools.codegen.SupportingFile;
-import org.openapitools.codegen.languages.features.BeanValidationFeatures;
-import org.openapitools.codegen.languages.features.OptionalFeatures;
-import org.openapitools.codegen.languages.features.UseGenericResponseFeatures;
-import org.openapitools.codegen.utils.ModelUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.File;
 import java.net.URI;
 import java.time.Duration;
@@ -47,6 +21,33 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.StringUtils;
+import org.openapitools.codegen.CliOption;
+import org.openapitools.codegen.CodegenConstants;
+import org.openapitools.codegen.CodegenModel;
+import org.openapitools.codegen.CodegenOperation;
+import org.openapitools.codegen.CodegenParameter;
+import org.openapitools.codegen.CodegenProperty;
+import org.openapitools.codegen.CodegenResponse;
+import org.openapitools.codegen.SpecValidationException;
+import org.openapitools.codegen.SupportingFile;
+import org.openapitools.codegen.languages.features.BeanValidationFeatures;
+import org.openapitools.codegen.languages.features.OptionalFeatures;
+import org.openapitools.codegen.languages.features.UseGenericResponseFeatures;
+import org.openapitools.codegen.utils.ModelUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.micronaut.core.util.CollectionUtils;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.MediaType;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.media.ComposedSchema;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.media.StringSchema;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.servers.Server;
 
 public class MicronautCodegen extends AbstractJavaCodegen
 		implements BeanValidationFeatures, UseGenericResponseFeatures, OptionalFeatures {

--- a/src/main/resources/Micronaut/modelPojo.mustache
+++ b/src/main/resources/Micronaut/modelPojo.mustache
@@ -14,7 +14,7 @@ public {{#discriminator}}abstract {{/discriminator}}class {{classname}}{{#parent
 {{/discriminator}}
 
 {{#vars}}{{#description}}	/** {{description}} */
-{{/description}}{{#useBeanValidation}}{{>modelPropertyValidation}}{{/useBeanValidation}}{{>modelPropertyJackson}}
+{{/description}}{{#useBeanValidation}}{{>modelPropertyValidation}}{{/useBeanValidation}}{{^annotateMethods}}{{>modelPropertyJackson}}{{/annotateMethods}}
 	private {{>modelPropertyType}} {{name}}{{>modelPropertyDefault}};
 
 {{/vars}}{{#vendorExtensions.additionalPropertiesMap}}
@@ -66,11 +66,13 @@ public {{#discriminator}}abstract {{/discriminator}}class {{classname}}{{#parent
 	// fluent
 	{{#vars}}
 
+    {{#annotateMethods}}{{>modelPropertyJackson}}{{/annotateMethods}}
 	public {{classname}} {{name}}({{>modelPropertyType}} new{{nameInCamelCase}}) {
 		this.{{name}} = new{{nameInCamelCase}};
 		return this;
 	}
 
+    {{#annotateMethods}}{{>modelPropertyJackson}}{{/annotateMethods}}
 	public {{>modelPropertyType}} {{name}}() {
 		return {{name}};
 	}
@@ -100,11 +102,12 @@ public {{#discriminator}}abstract {{/discriminator}}class {{classname}}{{#parent
 
 	{{/vendorExtensions.additionalPropertiesMap}}
 	{{#vars}}
-
+	{{#annotateMethods}}{{>modelPropertyJackson}}{{/annotateMethods}}
 	public {{>modelPropertyType}} {{getter}}() {
 		return {{name}};
 	}
 
+    {{#annotateMethods}}{{>modelPropertyJackson}}{{/annotateMethods}}
 	public {{classname}} {{setter}}({{>modelPropertyType}} new{{nameInCamelCase}}) {
 		this.{{name}} = new{{nameInCamelCase}};
 		return this;


### PR DESCRIPTION
When generating models from schemas using properties like isX or setX, jackson removes the "is" and "set" part by default. To preserve the prefix, the JsonProperty annotation has to be put on the method, instead of the field. The new configuration option enables that.